### PR TITLE
Add drag-and-drop connections page

### DIFF
--- a/src/app/components/Dashboard/Connections/page.tsx
+++ b/src/app/components/Dashboard/Connections/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useState } from 'react';
+import DashboardLayout from '../DashboardLayout';
+import {
+  ConnectionManager,
+  ConnectionHistory,
+  ConnectionTemplateSelector
+} from '../../widgets/connections';
+
+interface Widget {
+  id: string;
+}
+
+const ConnectionsPage: React.FC = () => {
+  const [widgets, setWidgets] = useState<Widget[]>([
+    { id: 'manager' },
+    { id: 'template' },
+    { id: 'history' }
+  ]);
+
+  const handleDragStart = (index: number) => (event: React.DragEvent<HTMLDivElement>) => {
+    event.dataTransfer.setData('text/plain', String(index));
+  };
+
+  const handleDrop = (index: number) => (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const fromIndex = Number(event.dataTransfer.getData('text/plain'));
+    if (fromIndex === index) return;
+    const newWidgets = [...widgets];
+    const [moved] = newWidgets.splice(fromIndex, 1);
+    newWidgets.splice(index, 0, moved);
+    setWidgets(newWidgets);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
+  const renderWidget = (id: string) => {
+    switch (id) {
+      case 'manager':
+        return <ConnectionManager showAddButton />;
+      case 'history':
+        return <ConnectionHistory connectionId="1" />;
+      case 'template':
+        return <ConnectionTemplateSelector />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="p-6 space-y-4">
+        <h1 className="text-2xl font-bold">Connections</h1>
+        <p className="text-gray-600">Drag and drop widgets to customize your layout.</p>
+        <div className="grid gap-4">
+          {widgets.map((widget, index) => (
+            <div
+              key={widget.id}
+              draggable
+              onDragStart={handleDragStart(index)}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop(index)}
+              className="bg-white border rounded shadow-sm p-2"
+            >
+              {renderWidget(widget.id)}
+            </div>
+          ))}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default ConnectionsPage;

--- a/src/components/widgets/connections/ConnectionTemplate.tsx
+++ b/src/components/widgets/connections/ConnectionTemplate.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../app/components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '../../app/components/ui/card';
+import { Button } from '../../app/components/ui/button';
+import { Input } from '../../app/components/ui/input';
+import { Label } from '../../app/components/ui/label';
+import { ConnectionSettings } from '../../types/connections';
+
+interface ConnectionTemplate {
+  id: string;
+  name: string;
+  settings: ConnectionSettings;
+}
+
+const DEFAULT_TEMPLATES: ConnectionTemplate[] = [
+  {
+    id: 'daily',
+    name: 'Daily Sync',
+    settings: {
+      auto_sync: true,
+      sync_frequency: 'daily',
+      data_retention_days: 90,
+      enabled_features: []
+    }
+  },
+  {
+    id: 'weekly',
+    name: 'Weekly Sync',
+    settings: {
+      auto_sync: true,
+      sync_frequency: 'weekly',
+      data_retention_days: 30,
+      enabled_features: []
+    }
+  }
+];
+
+export function ConnectionTemplateSelector() {
+  const [templates, setTemplates] = useState<ConnectionTemplate[]>(DEFAULT_TEMPLATES);
+  const [selected, setSelected] = useState<string>('');
+  const [newName, setNewName] = useState('');
+
+  const handleAddTemplate = () => {
+    if (!newName.trim()) return;
+    const newTemplate: ConnectionTemplate = {
+      id: newName.toLowerCase().replace(/\s+/g, '-'),
+      name: newName,
+      settings: DEFAULT_TEMPLATES[0].settings
+    };
+    setTemplates([...templates, newTemplate]);
+    setNewName('');
+  };
+
+  const selectedTemplate = templates.find(t => t.id === selected);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Connection Setting Templates</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="template">Select Template</Label>
+          <Select value={selected} onValueChange={setSelected}>
+            <SelectTrigger>
+              <SelectValue placeholder="Choose a template" />
+            </SelectTrigger>
+            <SelectContent>
+              {templates.map(t => (
+                <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {selectedTemplate && (
+          <pre className="bg-gray-100 p-2 rounded text-sm overflow-x-auto">
+{JSON.stringify(selectedTemplate.settings, null, 2)}
+          </pre>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="newTemplate">New Template Name</Label>
+          <Input id="newTemplate" value={newName} onChange={e => setNewName(e.target.value)} placeholder="My Template" />
+          <Button onClick={handleAddTemplate} size="sm">Add Template</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/widgets/connections/index.ts
+++ b/src/components/widgets/connections/index.ts
@@ -3,6 +3,7 @@ export { ConnectionManager } from './ConnectionManager';
 export { ConnectionStatus, ConnectionStatusDetailed, ConnectionStatusIndicator } from './ConnectionStatus';
 export { ConnectionWizard } from './ConnectionWizard';
 export { ConnectionHistory, ConnectionHistoryCompact } from './ConnectionHistory';
+export { ConnectionTemplateSelector } from './ConnectionTemplate';
 
 // Re-export types for convenience
 export type { Connection, ConnectionType, ConnectionStatus as ConnectionStatusType } from '../../../types/connections';


### PR DESCRIPTION
## Summary
- add a drag-and-drop connections page with `ConnectionManager`, `ConnectionHistory` and `ConnectionTemplateSelector` widgets
- create `ConnectionTemplateSelector` widget for managing connection setting templates
- export new widget

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b50f80bc8325ba10bed1723f9914